### PR TITLE
Metadata channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ erl_crash.dump
 # /priv/static/css
 # /priv/static/js
 .DS_Store
+
+.env

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,7 @@ config :chat, Chat.Endpoint,
   debug_errors: false,
   pubsub: [name: Chat.PubSub,
            adapter: Phoenix.PubSub.PG2],
-  check_origin: ["//datafruitstest.s3-website-us-east-1.amazonaws.com/", "//localhost:4200", "//localhost:3000", "//datafruits.fm", "//datafruits-fastboot.herokuapp.com/", "//www.datafruits.fm", "https://datafruits.fm", "https://www.datafruits.fm"]
+  check_origin: ["//datafruitstest.s3-website-us-east-1.amazonaws.com/", "//localhost:4200", "//localhost:3000", "//datafruits.fm", "//datafruits-fastboot.herokuapp.com/", "//www.datafruits.fm", "https://datafruits.fm", "https://www.datafruits.fm", "https://datafruits-photobooth.glitch.me"]
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -6,3 +6,5 @@ elixir_version=1.8.1
 
 # Do dependencies have to be built from scratch on every deploy?
 always_build_deps=false
+
+always_rebuild=true

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,7 @@ defmodule Chat.Mixfile do
      {:postgrex, "~> 0.11.0"},
      {:jason, "~> 1.0"},
      {:exredis, ">= 0.2.4"},
+     {:redix, ">= 0.0.0"},
      {:plug_cowboy, "~> 2.0"},
      {:plug, "~> 1.7"}]
   end

--- a/web/channels/metadata_channel.ex
+++ b/web/channels/metadata_channel.ex
@@ -1,0 +1,40 @@
+defmodule Chat.MetadataChannel do
+  use Phoenix.Channel
+  require Logger
+
+  def join("metadata", message, socket) do
+    {:ok, pubsub} = Redix.PubSub.start_link()
+
+    Redix.PubSub.subscribe(pubsub, "metadata", self())
+
+    {:ok, conn} = Redix.start_link()
+    {:ok, message} = Redix.command(conn, ["GET", "datafruits:metadata"])
+
+    send(self, {:after_join, message})
+    # push socket, "metadata", %{message: message}
+
+    {:ok, socket}
+  end
+
+  def handle_info({:after_join, message}, socket) do
+    push socket, "metadata", %{message: message}
+    {:noreply, socket}
+  end
+
+  # Avoid throwing an error when a subscribed message enters the channel
+  def handle_info({:redix_pubsub, _redix_pid, _ref, :subscribed, _}, socket) do
+    {:noreply, socket}
+  end
+
+  # Handle the message coming from the Redis PubSub channel
+  def handle_info({:redix_pubsub, _redix_id, _ref, :message, %{channel: channel, payload: message}}, socket) do
+    Logger.debug "got message from pubsub #{message} on #{channel}"
+    # do something with the message
+
+    # Push the message back to the user over the channel topic
+    # This assumes the message is already in a map
+    broadcast! socket, "metadata", %{message: message}
+
+    {:noreply, socket}
+  end
+end

--- a/web/channels/metadata_channel.ex
+++ b/web/channels/metadata_channel.ex
@@ -3,11 +3,11 @@ defmodule Chat.MetadataChannel do
   require Logger
 
   def join("metadata", message, socket) do
-    {:ok, pubsub} = Redix.PubSub.start_link()
+    {:ok, pubsub} = Redix.PubSub.start_link(password: System.get_env("REDIS_PASSWORD"))
 
-    Redix.PubSub.subscribe(pubsub, "metadata", self())
+    Redix.PubSub.subscribe(pubsub, "datafruits:metadata", self())
 
-    {:ok, conn} = Redix.start_link()
+    {:ok, conn} = Redix.start_link(password: System.get_env("REDIS_PASSWORD"))
     {:ok, message} = Redix.command(conn, ["GET", "datafruits:metadata"])
 
     send(self, {:after_join, message})

--- a/web/channels/room_channel.ex
+++ b/web/channels/room_channel.ex
@@ -28,6 +28,7 @@ defmodule Chat.RoomChannel do
   end
 
   def handle_info({:after_join, msg}, socket) do
+    Logger.debug("handle_info: #{Socket}")
     broadcast! socket, "user:entered", %{user: msg["user"]}
     logs = ChatLog.get_logs(socket.topic)
     Logger.info("logs: #{inspect logs}")
@@ -65,7 +66,6 @@ defmodule Chat.RoomChannel do
   end
 
   def handle_in(event, msg, socket) do
-    Logger.debug("handle_in!")
     case event do
       "new:msg" ->
         Logger.debug "#{msg["timestamp"]} -- sending new message from #{msg["user"]} : #{msg["body"]}"

--- a/web/channels/user_socket.ex
+++ b/web/channels/user_socket.ex
@@ -2,6 +2,7 @@ defmodule Chat.UserSocket do
   use Phoenix.Socket
 
   channel "rooms:*", Chat.RoomChannel
+  channel "metadata", Chat.MetadataChannel
 
   def connect(_params, socket) do
     {:ok, socket}


### PR DESCRIPTION
Add another phoenix channel to facilitate sending updates about stream metadata over websockets, instead of having to poll the icecast server on the datafruits frontend. Metadata updates are sent over redis pubsub.